### PR TITLE
Add Streamlit UI for PDF Q&A Assistant

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8  -*-
 # @Author  : Duguce 
 # @Email   : zhgyqc@163.com
@@ -7,6 +8,7 @@
 import os
 import sys
 import json
+import streamlit as st
 
 # PDF files path
 FILES = os.path.join(os.getcwd(), 'pdf_files')
@@ -28,34 +30,27 @@ def cls():
 
 
 def select_files():
-    """
-    Select the files
-    """
-    cls()
-    files = [file for file in os.listdir(FILES) if file.endswith('.pdf')]
-    if not files:
-        print("No PDF files in the folder")
+    st.title("PDF Q&A Assistant")
+    st.subheader("Please upload the PDFs you'd like to process")
+    uploaded_files = st.file_uploader("upload PDF files", accept_multiple_files=True, type=['pdf'], label_visibility='hidden')
+
+    if not uploaded_files:
+        st.warning("Please upload at least one PDF file to proceed.")
         return None
-    print("📁 Please select the file to process: ")
-    for i, file in enumerate(files):
-        print(f"{i + 1}. {file}")
-    print()
 
-    try:
-        possible_selections = list(range(len(files) + 1))
+    st.markdown("""---""")
 
-        selections = input("Please enter the file number, separate multiple files with spaces, or enter 0 to exit: ").split()
-        selections = [int(selection) for selection in selections]
+    os.makedirs(FILES, exist_ok=True)
 
-        if not set(selections).issubset(set(possible_selections)):
-            return select_files()
-        elif 0 in selections:
-            handle_exit()
-        else:
-            pdfs_path = [os.path.join(FILES, files[i - 1]) for i in selections]
-            return pdfs_path
-    except ValueError:
-        return select_files()
+    pdfs_path = []
+    for uploaded_file in uploaded_files:
+        file_path = os.path.join(FILES, uploaded_file.name)
+        pdfs_path.append(file_path)
+
+        with open(file_path, "wb") as f:
+            f.write(uploaded_file.getbuffer())
+
+    return pdfs_path
 
 
 def handle_exit():


### PR DESCRIPTION
Hello,

Thanks for this creative simplistic tool to process PDFs and exploit them using ChatGPT.
I managed to create a simple UI using Streamlit so that it can be usable for the average user and to have a seamless interaction by uploading multiple PDF files.

Description:

This pull request introduces a user-friendly Streamlit-based interface for the PDF Q&A Assistant. The primary changes in this update include:

1. Implemented a file upload UI in the `select_files()` function so users can easily upload their PDF files for processing.
2. Modified the `chat()` function to present the chatbot UI within the Streamlit application, allowing users to start a conversation about the uploaded documents (question-answer at this point, not an entire conversation).
3. Added a sidebar that displays a concise description of the tool and contains input fields for the user to set `OPENAI_API_KEY`, `OPENAI_API_BASE`, and `MAX_TOKENS` dynamically.
4. Updated the `main()` function to accommodate the new user interface and ensure proper functioning of the PDF Q&A Assistant within the Streamlit framework.
5. Using `GPT-4`  instead of `GPT-3.5` (maybe later on I'll add a choice list in the sidebar so that the user chooses the model.

These changes enhance the user experience by providing a more intuitive and accessible interface to query and interact with the contents of their PDF documents.

![image](https://github.com/Duguce/Mini-ChatPDF/assets/40344016/70575b84-0ec1-428b-b425-dc7d92b76c9d)
